### PR TITLE
Fix for #1

### DIFF
--- a/retype.py
+++ b/retype.py
@@ -170,10 +170,8 @@ def lib2to3_parse(src_txt):
     except ParseError as pe:
         lineno, column = pe.context[1]
         lines = src_txt.splitlines()
-        if lineno == len(lines) + 1 and column == 0:
-            faulty_line = "Perhaps the source is missing a trailing newline."
-        elif lineno < 0 or lineno > len(lines):
-            faulty_line = "<Line number does not exist in source>"
+        if src_txt[-1] != '\n':
+            faulty_line = "The source is missing a trailing newline."
         else:
             faulty_line = lines[lineno - 1]
         raise ValueError(f"Cannot parse: {lineno}:{column}: {faulty_line}") from None

--- a/retype.py
+++ b/retype.py
@@ -169,7 +169,13 @@ def lib2to3_parse(src_txt):
         result = drv.parse_string(src_txt, True)
     except ParseError as pe:
         lineno, column = pe.context[1]
-        faulty_line = src_txt.splitlines()[lineno - 1]
+        lines = src_txt.splitlines()
+        if lineno == len(lines) + 1 and column == 0:
+            faulty_line = "Perhaps the source is missing a trailing newline."
+        elif lineno < 0 or lineno > len(lines):
+            faulty_line = "<Line number does not exist in source>"
+        else:
+            faulty_line = lines[lineno - 1]
         raise ValueError(f"Cannot parse: {lineno}:{column}: {faulty_line}") from None
 
     if isinstance(result, Leaf):

--- a/tests/test_retype.py
+++ b/tests/test_retype.py
@@ -2142,7 +2142,7 @@ class ParseErrorTestCase(RetypeTestCase):
             pass"""
         exception = self.assertReapplyRaises(pyi_txt, src_txt, ValueError)
         self.assertEqual(
-            'Cannot parse: 4:0: Perhaps the source is missing a trailing newline.',
+            'Cannot parse: 4:0: The source is missing a trailing newline.',
             str(exception),
         )
 

--- a/tests/test_retype.py
+++ b/tests/test_retype.py
@@ -2134,6 +2134,17 @@ class PrintStmtTestCase(RetypeTestCase):
             str(exception),
         )
 
+class ParseErrorTestCase(RetypeTestCase):
+    def test_missing_trailing_newline_crash(self) -> None:
+        pyi_txt = "def f() -> None: ...\n"
+        src_txt = """
+        def f():
+            pass"""
+        exception = self.assertReapplyRaises(pyi_txt, src_txt, ValueError)
+        self.assertEqual(
+            'Cannot parse: 4:0: Perhaps the source is missing a trailing newline.',
+            str(exception),
+        )
 
 class PostProcessTestCase(RetypeTestCase):
     def test_straddling_variable_comments(self) -> None:


### PR DESCRIPTION
- Added handling for cases where the ParseError refers to lines that don't exist in the source.
- Specifically handling the missing newline case, because it is especially difficult to diagnose.

Fixes #1 