### PR TITLE
Don't accept type-ignore with trailing info

### DIFF
--- a/retype.py
+++ b/retype.py
@@ -1454,7 +1454,7 @@ _star = Leaf(token.STAR, '*')
 _ellipsis = Node(syms.atom, children=[new(_dot), new(_dot), new(_dot)])
 
 _type_comment_re = re.compile(
-    r'^[\t ]*# type: *(?P<type>[^\t\n]+)(?<!ignore)[ \t]*(?P<nl>\n?)$',
+    r'^[\t ]*# type:[\t ]*(?![\t ]*ignore\b)(?P<type>[^\t#]+)[^\n]*(?P<nl>\n?)$',
     re.MULTILINE,
 )
 


### PR DESCRIPTION
Previously, source code that looks like
`x = await Foo.get(user_id)  # type: ignore  # more comment`

Will be annotated to read:
x: ignore = await Foo.get(user_id)

The look-behind was matching the string following "#type: " with "ignore" exactly, and so appending anything after "ignore" will still match to the <type> named capture group.

This change uses a lookahead to refuse to match "#type: ignore" even if followed by further characters. "#type: ignoreSomething" is still accepted.

Play with this regex change: https://regex101.com/r/e2trZh/2/