### PR TITLE
[ast3.num] Add support for ast3.Num

### DIFF
--- a/retype.py
+++ b/retype.py
@@ -621,6 +621,11 @@ def _c_str(s):
     return Leaf(token.STRING, repr(s.s))
 
 
+@convert_annotation.register(ast3.Num)
+def _c_num(n):
+    return Leaf(token.NUMBER, repr(n.n))
+
+
 @convert_annotation.register(ast3.Index)
 def _c_index(index):
     return convert_annotation(index.value)


### PR DESCRIPTION
Noticed that this would throw an error when using retype:

```
# test.pyi 
def foo() -> typing_extensions.Literal[2]: ...
```