### PR TITLE
gitignore support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@ lib64/
 parts/
 sdist/
 var/
-*.egg-info/
+*.egg-info
 .installed.cfg
 *.egg
 
@@ -36,7 +36,7 @@ pip-delete-this-directory.txt
 
 # Unit test / coverage reports
 htmlcov/
-.tox/
+.tox
 .coverage
 .coverage.*
 .cache

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
         )
     ],
     zip_safe=False,
-    install_requires=["click", "typed-ast"],
+    install_requires=["click", "typed-ast", "pathspec >= 0.5.9, <1"],
     test_suite="tests.test_retype",
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,0 +1,56 @@
+from collections import namedtuple
+
+import pytest
+
+from retype import walk_not_git_ignored
+
+
+@pytest.fixture()
+def build(tmp_path):
+    def _build(files):
+        for file, content in files.items():
+            dest = tmp_path / file
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.write_text(content, encoding="utf-8")
+        return tmp_path
+
+    return _build
+
+
+Case = namedtuple("Case", ["files", "found", "cwd"])
+WALK_TESTS = {
+    "no_ignore_root": Case({"a.py": ""}, ["a.py"], "."),
+    "no_ignore_root_within": Case({"b/a.py": ""}, ["b/a.py"], "."),
+    "no_ignore_keep_py_only": Case(
+        {"a.py": "", "a.pyi": "", "b/a.pyi": "", "b/a.py": ""}, ["a.py", "b/a.py"], "."
+    ),
+    "ignore_py_at_root": Case(
+        {".gitignore": "*.py", "a.py": "", "b/a.py": ""}, [], "."
+    ),
+    "ignore_py_nested": Case(
+        {"a.py": "", "b/a.py": "", "b/.gitignore": "*.py"}, ["a.py"], "."
+    ),
+    "git_nested_no_res": Case(
+        {".git/demo": "", ".gitignore": "*.py", "b/c/d/a.py": ""}, [], "b/c/d"
+    ),
+    "git_nested_has_res": Case(
+        {".git/demo": "", "b/c/a.py": "", "b/c/d/.gitignore": "*.py", "b/c/d/a.py": ""},
+        ["a.py"],
+        "b/c",
+    ),
+}
+
+
+@pytest.mark.parametrize("case", WALK_TESTS.values(), ids=list(WALK_TESTS.keys()))
+def test_walk(case: Case, build, monkeypatch):
+    path = build(case.files)
+    dest = path / case.cwd
+    monkeypatch.chdir(dest)
+    result = [
+        str(f.relative_to(dest))
+        for f in walk_not_git_ignored(
+            dest, lambda p: p.suffix == ".py", extra_ignore=[]
+        )
+    ]
+    expected = [str(f) for f in case.found]
+    assert result == expected

--- a/tox.ini
+++ b/tox.ini
@@ -50,7 +50,7 @@ force_grid_wrap = 0
 use_parentheses = True
 line_length = 88
 known_first_party = retype
-known_third_party = click,setuptools,typed_ast
+known_third_party = click,pathspec,pytest,setuptools,typed_ast
 
 [testenv:lint]
 description = run the flake8 checker
@@ -72,11 +72,8 @@ description = try to merge our types against our types
 deps = pip >= 19.1.1
        mypy == 0.701
 changedir = {envtmpdir}
-commands = python -c 'import glob; import shutil; from pathlib import Path; \
-           [print(f, (Path()/"out"/shutil.copy(f, ".")).with_suffix(".py").absolute()) \
-           for f in glob.glob(r"{toxinidir}/*.py")]'
-           python '{envsitepackagesdir}/retype.py' -p "{toxinidir}/types" -t out .
-           mypy out --strict --ignore-missing-imports
+commands = python '{envsitepackagesdir}/retype.py' -p '{toxinidir}/types' -t {envtmpdir} {toxinidir}
+           mypy {envtmpdir} --strict --ignore-missing-imports {posargs}
 
 [testenv:package_readme]
 description = check that the long description is valid (need for PyPi)
@@ -89,7 +86,6 @@ commands = python -m pep517.build --out-dir {envtmpdir}/build --binary .
 
 [testenv:dev]
 description = generate a DEV environment
-deps = pip >= 19.1.1
 usedevelop = True
 commands = python -m pip list --format=columns
            python -c 'import sys; print(sys.executable)'

--- a/types/retype.pyi
+++ b/types/retype.pyi
@@ -2,6 +2,8 @@ from lib2to3.pytree import Leaf, Node
 from pathlib import Path
 from typing import (
     Callable,
+    Dict,
+    Generator,
     Iterable,
     Iterator,
     List,
@@ -12,6 +14,7 @@ from typing import (
     Union,
 )
 
+from pathspec import PathSpec
 from typed_ast import ast3
 
 _LN = Union[Node, Leaf]
@@ -149,3 +152,9 @@ def _dn_call(call: ast3.Call) -> List[str]: ...
 def _dn_attribute(attr: ast3.Attribute) -> List[str]: ...
 def _nuin_node(node: Node, name: Leaf) -> bool: ...
 def _nuin_leaf(leaf: Leaf, name: Leaf) -> bool: ...
+def walk_not_git_ignored(
+    path: Path, keep: Callable[[Path], bool], extra_ignore: List[str]
+) -> Generator[Path, None, None]: ...
+def _load_ignore(
+    at_path: Path, parent_spec: PathSpec, ignores: Dict[Path, PathSpec]
+) -> PathSpec: ...

--- a/types/tests/test_discovery.pyi
+++ b/types/tests/test_discovery.pyi
@@ -1,0 +1,15 @@
+from pathlib import Path
+from typing import Callable, Dict, NamedTuple
+
+from _pytest.monkeypatch import MonkeyPatch
+
+Case: NamedTuple = ...
+
+WALK_TESTS: Dict[str, Case]
+
+def build(tmp_path: Path) -> Callable[[Dict[str, str]], Path]:
+    def _build(files: Dict[str, str]) -> Path: ...
+
+def test_walk(
+    case: Case, build: Callable[[Dict[str, str]], Path], monkeypatch: MonkeyPatch
+) -> None: ...

--- a/types/tests/test_retype.pyi
+++ b/types/tests/test_retype.pyi
@@ -5,10 +5,22 @@ _E = TypeVar("_E", bound=Exception)
 
 class RetypeTestCase(TestCase):
     def assertReapply(
-        self, pyi_txt: str, src_txt: str, expected_txt: str, *, incremental: bool
+        self,
+        pyi_txt: str,
+        src_txt: str,
+        expected_txt: str,
+        *,
+        incremental: bool = ...,
+        replace_any: bool = ...,
     ) -> None: ...
     def assertReapplyVisible(
-        self, pyi_txt: str, src_txt: str, expected_txt: str, *, incremental: bool
+        self,
+        pyi_txt: str,
+        src_txt: str,
+        expected_txt: str,
+        *,
+        incremental: bool = ...,
+        replace_any: bool = ...,
     ) -> None: ...
     def assertReapplyRaises(
         self,
@@ -16,5 +28,6 @@ class RetypeTestCase(TestCase):
         src_txt: str,
         expected_exception: Type[_E],
         *,
-        incremental: bool,
+        incremental: bool = ...,
+        replace_any: bool = ...,
     ) -> _E: ...


### PR DESCRIPTION
- ignore files ignored by .gitignore (the only side effect compared to calling `` git ls-files '*.py'`` now is the global gitignore),
- allow source tree merge - before it merged only the root level, not nested folders