### PR TITLE
Don't error on empty files

### DIFF
--- a/src/retype/__init__.py
+++ b/src/retype/__init__.py
@@ -72,8 +72,11 @@ def retype_file(src, pyi_dir, targets, *, quiet=False, hg=False, flags=None):
     if flags is None:
         flags = ReApplyFlags()
     with tokenize.open(src) as src_buffer:
+        src_contents = src_buffer.read()
+        if src_contents == "":
+            return
         src_encoding = src_buffer.encoding
-        src_node = lib2to3_parse(src_buffer.read())
+        src_node = lib2to3_parse(src_contents)
     try:
         with open((pyi_dir / src.name).with_suffix(".pyi")) as pyi_file:
             pyi_txt = pyi_file.read()

--- a/tests/test_retype.py
+++ b/tests/test_retype.py
@@ -15,6 +15,7 @@ from retype import (
     fix_remaining_type_comments,
     lib2to3_parse,
     reapply_all,
+    retype_file,
     retype_path,
     serialize_attribute,
 )
@@ -28,6 +29,14 @@ def as_cwd(path):
         yield
     finally:
         os.chdir(old)
+
+
+def test_does_not_error_on_empty_file(tmp_path):
+    init_py = tmp_path / "__init__.py"
+    init_py.write_text("")
+    assert len(init_py.read_text()) == 0
+    retype_file(init_py, tmp_path, tmp_path)
+    assert len(init_py.read_text()) == 0
 
 
 def test_can_run_against_current_directory(tmp_path):


### PR DESCRIPTION
Empty files can't have any type comments to rewrite,
so skip processing them.

This avoids spurious errors like:
```
error: tests/__init__.py: string index out of range
```