### PR TITLE
Fix redefining aliases that uses `import typing`

### DIFF
--- a/src/retype/__init__.py
+++ b/src/retype/__init__.py
@@ -1135,10 +1135,11 @@ def maybe_replace_any_if_equal(name, expected, actual, flags):
     if not is_equal:
         expected_annotation = minimize_whitespace(str(expected))
         actual_annotation = minimize_whitespace(str(actual))
-        raise ValueError(
-            f"incompatible existing {name}. "
-            + f"Expected: {expected_annotation!r}, actual: {actual_annotation!r}"
-        )
+        if expected_annotation != actual_annotation:
+            raise ValueError(
+                f"incompatible existing {name}. "
+                + f"Expected: {expected_annotation!r}, actual: {actual_annotation!r}"
+            )
 
     return expected or actual
 

--- a/tests/test_retype.py
+++ b/tests/test_retype.py
@@ -2486,6 +2486,15 @@ class PostProcessTestCase(RetypeTestCase):
         self.assertReapply(pyi_txt, src_txt, expected_txt)
         self.assertReapplyVisible(pyi_txt, src_txt, expected_txt)
 
+    def test_overwriting_alias_with_typing(self) -> None:
+        file_content = """
+        import typing
+
+        OPTIONAL_STR = typing.Optional[str]
+        """
+
+        self.assertReapplyVisible(file_content, file_content, file_content)
+
 
 class TypeCommentReTestCase(TestCase):
     def assertMatch(self, input: str, *, type: str, nl: str) -> None:

--- a/tests/test_retype.py
+++ b/tests/test_retype.py
@@ -2490,7 +2490,28 @@ class PostProcessTestCase(RetypeTestCase):
         file_content = """
         import typing
 
-        OPTIONAL_STR = typing.Optional[str]
+        CUSTOM_TYPE = typing.Union[
+            str,
+            bytes,
+            None,
+            typing.List[typing.Union[str, bytes]],
+            typing.Tuple[typing.Union[str, bytes], ...],
+        ]
+        """
+
+        self.assertReapplyVisible(file_content, file_content, file_content)
+
+    def test_overwriting_alias_without_typing(self) -> None:
+        file_content = """
+        from typing import Union, List, Tuple
+
+        CUSTOM_TYPE = Union[
+            str,
+            bytes,
+            None,
+            List[Union[str, bytes]],
+            Tuple[Union[str, bytes], ...],
+        ]
         """
 
         self.assertReapplyVisible(file_content, file_content, file_content)


### PR DESCRIPTION
This is an attempt to solve #25. I'm not sure if that's the best solution, however, it works and it's pretty easy.  

The problem was that `actual` node object had 3 children: `typing (Leaf)`, `.Optional (Node)` and `[str] (Node)`, and `expected` object only 2 children: `typing.Optional (Leaf)`, `[str] (Node)`, which made them not equal. No idea why the same file is parsed differently, but the proposed solution ignores that problem.