### PR TITLE
remove schedule from GitHub workflow to keep it from getting disabled

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,8 +2,6 @@ name: check
 on:
   push:
   pull_request:
-  schedule:
-    - cron: "0 8 * * *"
 
 jobs:
   pre-commit:


### PR DESCRIPTION
The GitHub Workflow "check" had a notice that it was disabled because there was inactivity in this repository for at least 60 days. It didn't seem to be triggering for pull requests so it doesn't seem like this only affected the schedule part of the workflow :confused:.

The only documentation I found about this auto disable feature is [the warning at the top of this page](https://docs.github.com/en/actions/managing-workflow-runs/disabling-and-enabling-a-workflow#:~:text=Warning,days), and
I didn't see any official documentation on how to split a schedule out, but the documentation [to enable/disable them is here](https://docs.github.com/en/actions/managing-workflow-runs/disabling-and-enabling-a-workflow) and it looks like this has been discussed in the [community forums](https://github.community/t/do-disabled-scheduled-workflows-re-activate-on-repository-activity/160658), but I'm not sure if there's any issue tracker for this.

