### PR TITLE
fix string normalization

### DIFF
--- a/types/tests/test_retype.pyi
+++ b/types/tests/test_retype.pyi
@@ -1,9 +1,19 @@
-from typing import Type, TypeVar
+from lib2to3.pytree import Leaf, Node
+from typing import Tuple, Type, TypeVar, Union
 from unittest import TestCase
 
 _E = TypeVar("_E", bound=Exception)
+_LN = Union[Node, Leaf]
 
 class RetypeTestCase(TestCase):
+    def reapply(
+        self,
+        pyi_txt: str,
+        src_txt: str,
+        *,
+        incremental: bool = ...,
+        replace_any: bool = ...,
+    ) -> Tuple[_LN, _LN]: ...
     def assertReapply(
         self,
         pyi_txt: str,


### PR DESCRIPTION
This change updates annotation comparison to first normalize the original string leaf nodes to their repr form which is what is generated from the ast (the pyi file).

fixes #24 